### PR TITLE
Nav Bar Responsive Design

### DIFF
--- a/ComposureWatch/src/Components/Header/Header.jsx
+++ b/ComposureWatch/src/Components/Header/Header.jsx
@@ -7,12 +7,12 @@ import HamburgerSvg from "../SVG/HamburgerSvg";
 
 const Header = () => {
   return (
-    <div className="fixed top-4 right-0 left-0 z-[6]">
-      <header className="mx-4 px-12 py-3 flex justify-center lg:justify-start items-center space-x-6 border rounded-lg text-black bg-[rgba(229,235,244,0.95)] relative whitespace-nowrap">
+    <div className="fixed lg:top-4 right-0 left-0 z-[6]">
+      <header className="lg:mx-4 px-12 py-2 lg:py-3 flex justify-center lg:justify-start items-center lg:space-x-6 border lg:rounded-lg text-black bg-[rgba(229,235,244,0.95)] relative whitespace-nowrap">
         <div className="bg-white text-blue-400 hover:text-blue-300 cursor-pointer px-5 pt-4 h-full absolute left-0 top-0 font-bold text-xl uppercase tracking-tighter rounded-l-lg hidden lg:block">
           Blissard
         </div>
-        <div className="lg:hidden items-center flex absolute h-full left-0 top-0">
+        <div className="lg:hidden items-center flex absolute h-full left-3 top-0">
           <HamburgerSvg />
         </div>
         <img

--- a/ComposureWatch/src/Components/Header/Header.jsx
+++ b/ComposureWatch/src/Components/Header/Header.jsx
@@ -3,18 +3,22 @@ import HeaderListItemChevron from "./HeaderListItemChevron";
 import HeaderListItemUser from "./HeaderListItemUser";
 import SearchSvg from "../SVG/SearchSvg";
 import yinyang from "../../images/icons/kisspng-yin-and-yang-symbol-clip-art-ying-yang-5ac89db48a7b91.1364399115230970125672.png";
+import HamburgerSvg from "../SVG/HamburgerSvg";
 
 const Header = () => {
   return (
     <div className="fixed top-4 right-0 left-0 z-[6]">
       <header className="mx-4 px-12 py-3 flex justify-center lg:justify-start items-center space-x-6 border rounded-lg text-black bg-[rgba(229,235,244,0.95)] relative whitespace-nowrap">
-        <div className="bg-white text-blue-400 hover:text-blue-300 cursor-pointer px-5 pt-4 h-full absolute left-0 top-0 font-bold text-xl uppercase tracking-tighter rounded-l-lg">
+        <div className="bg-white text-blue-400 hover:text-blue-300 cursor-pointer px-5 pt-4 h-full absolute left-0 top-0 font-bold text-xl uppercase tracking-tighter rounded-l-lg hidden lg:block">
           Blissard
+        </div>
+        <div className="lg:hidden items-center flex absolute h-full left-0 top-0">
+          <HamburgerSvg />
         </div>
         <img
           src={yinyang}
           alt="yin-yang logo"
-          className="pl-20 h-10 opacity-100 hover:opacity-80 cursor-pointer "
+          className="lg:pl-20 h-10 opacity-100 hover:opacity-80 cursor-pointer "
         />
         <div>
           <ul className="flex flex-row justify-start">

--- a/ComposureWatch/src/Components/Header/Header.jsx
+++ b/ComposureWatch/src/Components/Header/Header.jsx
@@ -26,14 +26,16 @@ const Header = () => {
             <HeaderListItemChevron info="Game Info" />
             <HeaderListItem info="Heroes" />
             <HeaderListItem info="Season 3" />
-            <HeaderListItem info="News" />
-            <div className="hidden 2xl:block">
+            <div className="hidden min-[975px]:block">
+              <HeaderListItem info="News" />
+            </div>
+            <div className="hidden min-[1110px]:block">
               <HeaderListItemChevron info="Community" />
             </div>
-            <div className="hidden xl:block">
+            <div className="hidden min-[1180px]:block">
               <HeaderListItemChevron info="Shop" />
             </div>
-            <div className="hidden lg:block xl:block 2xl:hidden pl-2 h-full">
+            <div className="hidden min-[960px]:block min-[1180px]:hidden pl-2 h-full">
               <EllipsesSvg />
             </div>
           </ul>

--- a/ComposureWatch/src/Components/Header/Header.jsx
+++ b/ComposureWatch/src/Components/Header/Header.jsx
@@ -31,9 +31,11 @@ const Header = () => {
           <ul className="flex flex-row justify-start">
             <HeaderListItemUser info="Account" />
           </ul>
-          <button className="bg-orange-600  px-3 py-2 ml-6 uppercase font-semibold rounded-md opacity-100 text-white hover:opacity-80 inline-block">
-            Try now
-          </button>
+          <div className="hidden lg:block">
+            <button className="bg-orange-600  px-3 py-2 ml-6 uppercase font-semibold rounded-md opacity-100 text-white hover:opacity-80 inline-block">
+              Try now
+            </button>
+          </div>
         </div>
       </header>
     </div>

--- a/ComposureWatch/src/Components/Header/Header.jsx
+++ b/ComposureWatch/src/Components/Header/Header.jsx
@@ -4,6 +4,7 @@ import HeaderListItemUser from "./HeaderListItemUser";
 import SearchSvg from "../SVG/SearchSvg";
 import yinyang from "../../images/icons/kisspng-yin-and-yang-symbol-clip-art-ying-yang-5ac89db48a7b91.1364399115230970125672.png";
 import HamburgerSvg from "../SVG/HamburgerSvg";
+import EllipsesSvg from "../SVG/EllipsesSvg";
 
 const Header = () => {
   return (
@@ -26,8 +27,15 @@ const Header = () => {
             <HeaderListItem info="Heroes" />
             <HeaderListItem info="Season 3" />
             <HeaderListItem info="News" />
-            <HeaderListItemChevron info="Community" />
-            <HeaderListItemChevron info="Shop" />
+            <div className="hidden lg:block">
+              <HeaderListItemChevron info="Community" />
+            </div>
+            <div className="hidden xl:block">
+              <HeaderListItemChevron info="Shop" />
+            </div>
+            <div className="hidden">
+              <EllipsesSvg />
+            </div>
           </ul>
         </div>
         <div className="items-center flex absolute h-full right-3 top-0">

--- a/ComposureWatch/src/Components/Header/Header.jsx
+++ b/ComposureWatch/src/Components/Header/Header.jsx
@@ -7,7 +7,7 @@ import yinyang from "../../images/icons/kisspng-yin-and-yang-symbol-clip-art-yin
 const Header = () => {
   return (
     <div className="fixed top-4 right-0 left-0 z-[6]">
-      <header className="mx-4 px-12 py-3 flex justify-start items-center space-x-6 border rounded-lg text-black bg-[rgba(229,235,244,0.95)] relative whitespace-nowrap">
+      <header className="mx-4 px-12 py-3 flex justify-center lg:justify-start items-center space-x-6 border rounded-lg text-black bg-[rgba(229,235,244,0.95)] relative whitespace-nowrap">
         <div className="bg-white text-blue-400 hover:text-blue-300 cursor-pointer px-5 pt-4 h-full absolute left-0 top-0 font-bold text-xl uppercase tracking-tighter rounded-l-lg">
           Blissard
         </div>

--- a/ComposureWatch/src/Components/Header/Header.jsx
+++ b/ComposureWatch/src/Components/Header/Header.jsx
@@ -8,32 +8,32 @@ import EllipsesSvg from "../SVG/EllipsesSvg";
 
 const Header = () => {
   return (
-    <div className="fixed lg:top-4 right-0 left-0 z-[6]">
-      <header className="lg:mx-4 px-12 py-2 lg:py-3 flex justify-center lg:justify-start items-center lg:space-x-6 border lg:rounded-lg text-black bg-[rgba(229,235,244,0.95)] relative whitespace-nowrap">
-        <div className="bg-white text-blue-400 hover:text-blue-300 cursor-pointer px-5 pt-4 h-full absolute left-0 top-0 font-bold text-xl uppercase tracking-tighter rounded-l-lg hidden lg:block">
+    <div className="fixed md:top-4 right-0 left-0 z-[6]">
+      <header className="md:mx-4 px-12 py-2 md:py-3 flex justify-center md:justify-start items-center md:space-x-6 border md:rounded-lg text-black bg-[rgba(229,235,244,0.95)] relative whitespace-nowrap">
+        <div className="bg-white text-blue-400 hover:text-blue-300 cursor-pointer px-5 pt-4 h-full absolute left-0 top-0 font-bold text-xl uppercase tracking-tighter rounded-l-lg hidden md:block">
           Blissard
         </div>
-        <div className="lg:hidden items-center flex absolute h-full left-3 top-0">
+        <div className="md:hidden items-center flex absolute h-full left-3 top-0">
           <HamburgerSvg />
         </div>
         <img
           src={yinyang}
           alt="yin-yang logo"
-          className="lg:pl-20 h-10 opacity-100 hover:opacity-80 cursor-pointer "
+          className="md:pl-20 h-10 opacity-100 hover:opacity-80 cursor-pointer "
         />
         <div>
-          <ul className="flex flex-row justify-start">
+          <ul className="flex flex-row justify-start items-center gap-x-1">
             <HeaderListItemChevron info="Game Info" />
             <HeaderListItem info="Heroes" />
             <HeaderListItem info="Season 3" />
             <HeaderListItem info="News" />
-            <div className="hidden lg:block">
+            <div className="hidden 2xl:block">
               <HeaderListItemChevron info="Community" />
             </div>
             <div className="hidden xl:block">
               <HeaderListItemChevron info="Shop" />
             </div>
-            <div className="hidden">
+            <div className="hidden lg:block xl:block 2xl:hidden pl-2 h-full">
               <EllipsesSvg />
             </div>
           </ul>
@@ -43,7 +43,7 @@ const Header = () => {
           <ul className="flex flex-row justify-start">
             <HeaderListItemUser info="Account" />
           </ul>
-          <div className="hidden lg:block">
+          <div className="hidden md:block">
             <button className="bg-orange-600  px-3 py-2 ml-6 uppercase font-semibold rounded-md opacity-100 text-white hover:opacity-80 inline-block">
               Try now
             </button>

--- a/ComposureWatch/src/Components/Header/HeaderListItem.jsx
+++ b/ComposureWatch/src/Components/Header/HeaderListItem.jsx
@@ -1,6 +1,6 @@
 const HeaderListItem = ({ info }) => {
   return (
-    <li className="hidden lg:block">
+    <li className="hidden md:block">
       <a
         className="block py-2 pl-3 pr-4 text-lg leading-5 font-medium text-left"
         href="#"

--- a/ComposureWatch/src/Components/Header/HeaderListItem.jsx
+++ b/ComposureWatch/src/Components/Header/HeaderListItem.jsx
@@ -1,6 +1,6 @@
 const HeaderListItem = ({ info }) => {
   return (
-    <li className="hidden lg:visible">
+    <li className="hidden lg:block">
       <a
         className="block py-2 pl-3 pr-4 text-lg leading-5 font-medium text-left"
         href="#"

--- a/ComposureWatch/src/Components/Header/HeaderListItem.jsx
+++ b/ComposureWatch/src/Components/Header/HeaderListItem.jsx
@@ -1,6 +1,6 @@
 const HeaderListItem = ({ info }) => {
   return (
-    <li>
+    <li className="hidden lg:visible">
       <a
         className="block py-2 pl-3 pr-4 text-lg leading-5 font-medium text-left"
         href="#"

--- a/ComposureWatch/src/Components/Header/HeaderListItemChevron.jsx
+++ b/ComposureWatch/src/Components/Header/HeaderListItemChevron.jsx
@@ -4,7 +4,7 @@ const HeaderListItemChevron = ({ info }) => {
   return (
     <li className="flex flex-row items-center ">
       <a
-        className="py-2 pl-3 pr-1 text-lg leading-5 font-medium text-left hidden lg:block"
+        className="py-2 pl-1 pr-1 text-lg leading-5 font-medium text-left hidden md:block"
         href="#"
       >
         {info}

--- a/ComposureWatch/src/Components/Header/HeaderListItemChevron.jsx
+++ b/ComposureWatch/src/Components/Header/HeaderListItemChevron.jsx
@@ -2,14 +2,16 @@ import ChevronSvg from "../SVG/ChevronSvg";
 
 const HeaderListItemChevron = ({ info }) => {
   return (
-    <li className="flex flex-row items-center invisible lg:visible">
+    <li className="flex flex-row items-center ">
       <a
-        className="block py-2 pl-3 pr-1 text-lg leading-5 font-medium text-left"
+        className="py-2 pl-3 pr-1 text-lg leading-5 font-medium text-left hidden lg:block"
         href="#"
       >
         {info}
       </a>
-      <ChevronSvg />
+      <div className="hidden lg:block">
+        <ChevronSvg />
+      </div>
     </li>
   );
 };

--- a/ComposureWatch/src/Components/Header/HeaderListItemChevron.jsx
+++ b/ComposureWatch/src/Components/Header/HeaderListItemChevron.jsx
@@ -2,7 +2,7 @@ import ChevronSvg from "../SVG/ChevronSvg";
 
 const HeaderListItemChevron = ({ info }) => {
   return (
-    <li className="flex flex-row items-center">
+    <li className="flex flex-row items-center invisible lg:visible">
       <a
         className="block py-2 pl-3 pr-1 text-lg leading-5 font-medium text-left"
         href="#"

--- a/ComposureWatch/src/Components/Header/HeaderListItemUser.jsx
+++ b/ComposureWatch/src/Components/Header/HeaderListItemUser.jsx
@@ -4,16 +4,14 @@ import UserSvg from "../SVG/UserSvg";
 const HeaderListItemUser = ({ info }) => {
   return (
     <li className="flex flex-row items-center justify-end lg:justify-start pr-2">
-      <div className="">
-        <UserSvg />
-      </div>
+      <UserSvg />
       <a
-        className="block py-2 pl-1 pr-1 text-lg leading-5 font-medium text-left hidden lg:visible"
+        className="py-2 pl-1 pr-1 text-lg leading-5 font-medium text-left hidden lg:block"
         href="#"
       >
         {info}
       </a>
-      <div className="hidden lg:visible">
+      <div className="hidden lg:block">
         <ChevronSvg />
       </div>
     </li>

--- a/ComposureWatch/src/Components/Header/HeaderListItemUser.jsx
+++ b/ComposureWatch/src/Components/Header/HeaderListItemUser.jsx
@@ -3,15 +3,19 @@ import UserSvg from "../SVG/UserSvg";
 
 const HeaderListItemUser = ({ info }) => {
   return (
-    <li className="flex flex-row items-center pr-2">
-      <UserSvg />
+    <li className="flex flex-row items-center justify-end lg:justify-start pr-2">
+      <div className="">
+        <UserSvg />
+      </div>
       <a
-        className="block py-2 pl-1 pr-1 text-lg leading-5 font-medium text-left"
+        className="block py-2 pl-1 pr-1 text-lg leading-5 font-medium text-left hidden lg:visible"
         href="#"
       >
         {info}
       </a>
-      <ChevronSvg />
+      <div className="hidden lg:visible">
+        <ChevronSvg />
+      </div>
     </li>
   );
 };

--- a/ComposureWatch/src/Components/Header/HeaderListItemUser.jsx
+++ b/ComposureWatch/src/Components/Header/HeaderListItemUser.jsx
@@ -3,15 +3,15 @@ import UserSvg from "../SVG/UserSvg";
 
 const HeaderListItemUser = ({ info }) => {
   return (
-    <li className="flex flex-row items-center justify-end lg:justify-start pr-2">
+    <li className="flex flex-row items-center justify-end md:justify-start pr-2">
       <UserSvg />
       <a
-        className="py-2 pl-1 pr-1 text-lg leading-5 font-medium text-left hidden lg:block"
+        className="py-2 pl-1 pr-1 text-lg leading-5 font-medium text-left hidden md:block"
         href="#"
       >
         {info}
       </a>
-      <div className="hidden lg:block">
+      <div className="hidden md:block">
         <ChevronSvg />
       </div>
     </li>

--- a/ComposureWatch/src/Components/SVG/EllipsesSvg.jsx
+++ b/ComposureWatch/src/Components/SVG/EllipsesSvg.jsx
@@ -1,0 +1,22 @@
+const EllipsesSvg = () => {
+  return (
+    <li className="flex flex-row items-center">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className="w-6 h-6"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M6.75 12a.75.75 0 11-1.5 0 .75.75 0 011.5 0zM12.75 12a.75.75 0 11-1.5 0 .75.75 0 011.5 0zM18.75 12a.75.75 0 11-1.5 0 .75.75 0 011.5 0z"
+        />
+      </svg>
+    </li>
+  );
+};
+
+export default EllipsesSvg;

--- a/ComposureWatch/src/Components/SVG/HamburgerSvg.jsx
+++ b/ComposureWatch/src/Components/SVG/HamburgerSvg.jsx
@@ -1,22 +1,20 @@
 const HamburgerSvg = () => {
   return (
     <li className="flex flex-row items-center">
-      <div className="lg:hidden">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={1.5}
-          stroke="currentColor"
-          className="w-6 h-6 stroke-[#000] ml-0"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
-          />
-        </svg>
-      </div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className="w-6 h-6 stroke-[#000] ml-0"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+        />
+      </svg>
     </li>
   );
 };

--- a/ComposureWatch/src/Components/SVG/HamburgerSvg.jsx
+++ b/ComposureWatch/src/Components/SVG/HamburgerSvg.jsx
@@ -1,0 +1,24 @@
+const HamburgerSvg = () => {
+  return (
+    <li className="flex flex-row items-center">
+      <div className="lg:hidden">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          className="w-6 h-6 stroke-[#6b7280] ml-0"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+          />
+        </svg>
+      </div>
+    </li>
+  );
+};
+
+export default HamburgerSvg;

--- a/ComposureWatch/src/Components/SVG/HamburgerSvg.jsx
+++ b/ComposureWatch/src/Components/SVG/HamburgerSvg.jsx
@@ -8,7 +8,7 @@ const HamburgerSvg = () => {
           viewBox="0 0 24 24"
           strokeWidth={1.5}
           stroke="currentColor"
-          className="w-6 h-6 stroke-[#6b7280] ml-0"
+          className="w-6 h-6 stroke-[#000] ml-0"
         >
           <path
             strokeLinecap="round"

--- a/ComposureWatch/src/Components/SVG/SearchSvg.jsx
+++ b/ComposureWatch/src/Components/SVG/SearchSvg.jsx
@@ -1,7 +1,7 @@
 const SearchSvg = () => {
   return (
     <li className="flex flex-row items-center pr-8">
-      <div className="hidden lg:visible">
+      <div className="hidden lg:block">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"

--- a/ComposureWatch/src/Components/SVG/SearchSvg.jsx
+++ b/ComposureWatch/src/Components/SVG/SearchSvg.jsx
@@ -1,20 +1,22 @@
 const SearchSvg = () => {
   return (
     <li className="flex flex-row items-center pr-8">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
-        strokeWidth="2px"
-        stroke="currentColor"
-        className="w-6 h-6 stroke-[#6b7280]"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-        />
-      </svg>
+      <div className="hidden lg:visible">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth="2px"
+          stroke="currentColor"
+          className="w-6 h-6 stroke-[#6b7280]"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+          />
+        </svg>
+      </div>
     </li>
   );
 };

--- a/ComposureWatch/src/Components/SVG/SearchSvg.jsx
+++ b/ComposureWatch/src/Components/SVG/SearchSvg.jsx
@@ -1,7 +1,7 @@
 const SearchSvg = () => {
   return (
     <li className="flex flex-row items-center pr-8">
-      <div className="hidden lg:block">
+      <div className="hidden md:block">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"

--- a/ComposureWatch/src/Components/SVG/UserSvg.jsx
+++ b/ComposureWatch/src/Components/SVG/UserSvg.jsx
@@ -6,7 +6,7 @@ const UserSvg = () => {
       viewBox="0 0 24 24"
       strokeWidth="2px"
       stroke="currentColor"
-      className="w-6 h-6 stroke-[#6b7280]"
+      className="w-6 h-6 stroke-[#000] lg:stroke-[#6b7280]"
     >
       <path
         strokeLinecap="round"

--- a/ComposureWatch/tailwind.config.cjs
+++ b/ComposureWatch/tailwind.config.cjs
@@ -3,6 +3,22 @@ module.exports = {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {},
+    screens: {
+      sm: "640px",
+      // => @media (min-width: 640px) { ... }
+
+      md: "960px",
+      // => @media (min-width: 960px) { ... }
+
+      lg: "1024px",
+      // => @media (min-width: 1024px) { ... }
+
+      xl: "1280px",
+      // => @media (min-width: 1280px) { ... }
+
+      "2xl": "1536px",
+      // => @media (min-width: 1536px) { ... }
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
**What did you do?**

- Updated navigation bar to be responsive
- Created custom break points for nav bar items to prevent overlap when screen width reaches minimum sizes.
- Created custom medium media query.  Notice the size and positioning of the header itself becomes much simpler for at this screen size.

**Why did you do it?**

- Composure watch should be responsive across multiple screen types. This commit is the first step towards making that a reality.
- The multiple custom breakpoints were frustrating, but it allowed for a good study case in breakpoints and responsive design.
- These changes will provide an overall better user experience through ease of navigation.
- It looks much better.

Screenshot before:

![image](https://user-images.githubusercontent.com/6788405/230691367-320c104c-79ae-46c9-945e-36714d5ae17f.png)

![image](https://user-images.githubusercontent.com/6788405/230691315-fe4aba36-f21e-4631-8c6f-fbbb5256f424.png)


**Screenshot after:**
![image](https://user-images.githubusercontent.com/6788405/230691200-4a10f594-5bf4-4603-813f-665c6c503413.png)

![image](https://user-images.githubusercontent.com/6788405/230691278-a80bb32e-5b6f-48e8-a18f-6ecea6b4fcf9.png)


