### PR TITLE
Zgrid Card Styled Components

### DIFF
--- a/ComposureWatch/src/Components/UI/PurposeSection.jsx
+++ b/ComposureWatch/src/Components/UI/PurposeSection.jsx
@@ -1,11 +1,12 @@
 import kiriko from "../../images/UI/Kiriko.jpg";
+import Zcontentgrid from "./ZGridComponent/Zcontentgrid";
 import Zgrid from "./ZGridComponent/Zgrid";
 
 const PurposeSection = () => {
   return (
     <div className="from-[#66c4ff] bg-gradient-to-tr via-[#33b1ff]to-[#009dff] flex items-center justify-center">
       <Zgrid>
-        <div className="grid grid-cols-1 justify-items-center content-center text-center max-w-[650px]  md:text-left">
+        <Zcontentgrid>
           <h2 className="text-4xl sm:text-6xl font-bold uppercase">
             A NEW ERA HAS BEGUN
           </h2>
@@ -15,7 +16,7 @@ const PurposeSection = () => {
             in the way of a good gaming session, especially when playing with
             friends. Lorem ipsum dolor sit amet consectetur, adipisicing elit.
           </p>
-        </div>
+        </Zcontentgrid>
         <div className="self-start">
           <img src={kiriko} alt="Kiriko Image" className="rounded" />
         </div>

--- a/ComposureWatch/src/Components/UI/PurposeSection.jsx
+++ b/ComposureWatch/src/Components/UI/PurposeSection.jsx
@@ -1,31 +1,25 @@
 import kiriko from "../../images/UI/Kiriko.jpg";
+import Zgrid from "./ZGridComponent/Zgrid";
 
 const PurposeSection = () => {
   return (
     <div className="from-[#66c4ff] bg-gradient-to-tr via-[#33b1ff]to-[#009dff] flex items-center justify-center">
-      <div
-        className="grid grid-cols-1 md:grid-cols-[40fr,60fr] 
-      gap-x-20 max-[1200px]:gap-x-10 sm:gap-y-8 gap-y-6 px-4 py-10 sm:px-6 sm:py-16 md:px-10 md:py-20
-      justify-items-center items-center  font-[rgb(29, 37, 58)] max-w-[1600px]"
-      >
-        <div className="flex justify-center">
-          <div className="grid grid-cols-1 justify-items-center content-center text-center max-w-[650px]  md:text-left">
-            <h2 className="text-4xl sm:text-6xl font-bold uppercase">
-              A NEW ERA HAS BEGUN
-            </h2>
-            <p className="mt-6 font-base sm:text-xl">
-              ComposureWatch is a free-to-use, team-based tool made to ensure
-              balance amongst team creation in internal games. Nothing should
-              get in the way of a good gaming session, especially when playing
-              with friends. Lorem ipsum dolor sit amet consectetur, adipisicing
-              elit.
-            </p>
-          </div>
+      <Zgrid>
+        <div className="grid grid-cols-1 justify-items-center content-center text-center max-w-[650px]  md:text-left">
+          <h2 className="text-4xl sm:text-6xl font-bold uppercase">
+            A NEW ERA HAS BEGUN
+          </h2>
+          <p className="mt-6 font-base sm:text-xl">
+            ComposureWatch is a free-to-use, team-based tool made to ensure
+            balance amongst team creation in internal games. Nothing should get
+            in the way of a good gaming session, especially when playing with
+            friends. Lorem ipsum dolor sit amet consectetur, adipisicing elit.
+          </p>
         </div>
         <div className="self-start">
           <img src={kiriko} alt="Kiriko Image" className="rounded" />
         </div>
-      </div>
+      </Zgrid>
     </div>
   );
 };

--- a/ComposureWatch/src/Components/UI/PurposeSection.jsx
+++ b/ComposureWatch/src/Components/UI/PurposeSection.jsx
@@ -1,15 +1,18 @@
 import kiriko from "../../images/UI/Kiriko.jpg";
 import Zcontentgrid from "./ZGridComponent/Zcontentgrid";
 import Zgrid from "./ZGridComponent/Zgrid";
+import Zheader from "./ZGridComponent/Zheader";
 
 const PurposeSection = () => {
+  let header = "A NEW ERA HAS BEGUN";
+  let content =
+    "ComposureWatch is a free-to-use, team-based tool made to ensure balance amongst team creation in internal games. Nothing should get in the way of a good gaming session, especially when playing with friends. Lorem ipsum dolor sit amet consectetur, adipisicing elit.";
+
   return (
     <div className="from-[#66c4ff] bg-gradient-to-tr via-[#33b1ff]to-[#009dff] flex items-center justify-center">
       <Zgrid>
         <Zcontentgrid>
-          <h2 className="text-4xl sm:text-6xl font-bold uppercase">
-            A NEW ERA HAS BEGUN
-          </h2>
+          <Zheader header={header} />
           <p className="mt-6 font-base sm:text-xl">
             ComposureWatch is a free-to-use, team-based tool made to ensure
             balance amongst team creation in internal games. Nothing should get

--- a/ComposureWatch/src/Components/UI/PurposeSection.jsx
+++ b/ComposureWatch/src/Components/UI/PurposeSection.jsx
@@ -2,27 +2,23 @@ import kiriko from "../../images/UI/Kiriko.jpg";
 import Zcontentgrid from "./ZGridComponent/Zcontentgrid";
 import Zgrid from "./ZGridComponent/Zgrid";
 import Zheader from "./ZGridComponent/Zheader";
+import Zcontent from "./ZGridComponent/Zcontent";
+import Zimage from "./ZGridComponent/Zimage";
 
 const PurposeSection = () => {
   let header = "A NEW ERA HAS BEGUN";
   let content =
     "ComposureWatch is a free-to-use, team-based tool made to ensure balance amongst team creation in internal games. Nothing should get in the way of a good gaming session, especially when playing with friends. Lorem ipsum dolor sit amet consectetur, adipisicing elit.";
+  let alt = "Kiriko Image";
 
   return (
     <div className="from-[#66c4ff] bg-gradient-to-tr via-[#33b1ff]to-[#009dff] flex items-center justify-center">
       <Zgrid>
         <Zcontentgrid>
           <Zheader header={header} />
-          <p className="mt-6 font-base sm:text-xl">
-            ComposureWatch is a free-to-use, team-based tool made to ensure
-            balance amongst team creation in internal games. Nothing should get
-            in the way of a good gaming session, especially when playing with
-            friends. Lorem ipsum dolor sit amet consectetur, adipisicing elit.
-          </p>
+          <Zcontent content={content} />
         </Zcontentgrid>
-        <div className="self-start">
-          <img src={kiriko} alt="Kiriko Image" className="rounded" />
-        </div>
+        <Zimage img={kiriko} alt={alt} />
       </Zgrid>
     </div>
   );

--- a/ComposureWatch/src/Components/UI/ZGridComponent/Zcontent.jsx
+++ b/ComposureWatch/src/Components/UI/ZGridComponent/Zcontent.jsx
@@ -1,0 +1,4 @@
+const Zcontent = ({ content }) => {
+  return <p className="mt-6 font-base sm:text-xl">{content}</p>;
+};
+export default Zcontent;

--- a/ComposureWatch/src/Components/UI/ZGridComponent/Zcontentgrid.jsx
+++ b/ComposureWatch/src/Components/UI/ZGridComponent/Zcontentgrid.jsx
@@ -1,0 +1,9 @@
+function Zcontentgrid({ children }) {
+  const classes =
+    "grid grid-cols-1 justify-items-center content-center text-center md:text-left max-w-[700px] " +
+    children.className;
+
+  return <div className={classes}>{children}</div>;
+}
+
+export default Zcontentgrid;

--- a/ComposureWatch/src/Components/UI/ZGridComponent/Zgrid.jsx
+++ b/ComposureWatch/src/Components/UI/ZGridComponent/Zgrid.jsx
@@ -1,6 +1,6 @@
 const Zgrid = ({ children }) => {
   const classes =
-    "grid grid-cols-1 md:grid-cols-[40fr,60fr] gap-x-20 max-[1200px]:gap-x-10 sm:gap-y-8 gap-y-6 px-4 py-10 sm:px-6 sm:py-16 md:px-10 md:py-20 justify-items-center items-center  font-[rgb(29, 37, 58)] max-w-[1600px]" +
+    "grid grid-cols-1 md:grid-cols-[40fr,60fr] gap-x-20 max-[1200px]:gap-x-10 sm:gap-y-8 gap-y-6 px-4 py-10 sm:px-6 sm:py-16 md:px-10 md:py-20 justify-items-center items-center  font-[rgb(29, 37, 58)] max-w-[1600px] " +
     children.className;
 
   return <div className={classes}>{children}</div>;

--- a/ComposureWatch/src/Components/UI/ZGridComponent/Zgrid.jsx
+++ b/ComposureWatch/src/Components/UI/ZGridComponent/Zgrid.jsx
@@ -1,0 +1,8 @@
+const Zgrid = ({ children }) => {
+  const classes =
+    "grid grid-cols-1 md:grid-cols-[40fr,60fr] gap-x-20 max-[1200px]:gap-x-10 sm:gap-y-8 gap-y-6 px-4 py-10 sm:px-6 sm:py-16 md:px-10 md:py-20 justify-items-center items-center  font-[rgb(29, 37, 58)] max-w-[1600px]" +
+    children.className;
+
+  return <div className={classes}>{children}</div>;
+};
+export default Zgrid;

--- a/ComposureWatch/src/Components/UI/ZGridComponent/Zheader.jsx
+++ b/ComposureWatch/src/Components/UI/ZGridComponent/Zheader.jsx
@@ -1,0 +1,4 @@
+const Zheader = ({ header }) => {
+  return <h2 className="text-4xl sm:text-6xl font-bold uppercase">{header}</h2>;
+};
+export default Zheader;

--- a/ComposureWatch/src/Components/UI/ZGridComponent/Zimage.jsx
+++ b/ComposureWatch/src/Components/UI/ZGridComponent/Zimage.jsx
@@ -1,0 +1,9 @@
+const Zimage = ({ img, alt }) => {
+  return (
+    <div className="self-start">
+      <img src={img} alt={alt} className="rounded" />
+    </div>
+  );
+};
+
+export default Zimage;


### PR DESCRIPTION
**What did you do?**
Broke down  purpose section into reusable components.  These components can be reused and rearranged for other cards that follow the z-grid layout of exposure watch.  At the moment, these components are applicable to the PurposeSection and OverviewSection components.  If more cards are added in the future, these components will make the process much easier.

**New Components added:**

- Zcontent
- ZcontentGrid
- Zgrid
- Zheader
- Zimage

**Why did you do it?**
The PurposeSection and OverviewSection cards are similar enough in styling that DRY should be implemented.  By breaking down the PurposeSection in smaller components, they can be re-arranged and applied to both the OverviewSection and any other future card section.
