### PR TITLE
Overview Section Responsive Refactoring

### DIFF
--- a/ComposureWatch/src/Components/UI/Overview.jsx
+++ b/ComposureWatch/src/Components/UI/Overview.jsx
@@ -1,6 +1,6 @@
 import doomfist from "../../images/UI/Doomfist.png";
 import Zcontentgrid from "./ZGridComponent/Zcontentgrid";
-import Zgrid from "./ZGridComponent/Zgrid";
+import Zgridright from "./ZGridComponent/Zgridright";
 import Zheader from "./ZGridComponent/Zheader";
 import Zcontent from "./ZGridComponent/Zcontent";
 import Zimage from "./ZGridComponent/Zimage";
@@ -12,7 +12,7 @@ const Overview = () => {
   let alt = "Doomfist Image";
   return (
     <div className="bg-gradient-to-tr from-[#AE1518] via-[#8C1114] to-[#5B0B0E] flex justify-center">
-      <Zgrid>
+      <Zgridright>
         <Zimage img={doomfist} alt={alt} />
         <Zcontentgrid>
           <Zheader header={header} />
@@ -24,7 +24,7 @@ const Overview = () => {
             Learn More
           </button>
         </Zcontentgrid>
-      </Zgrid>
+      </Zgridright>
     </div>
   );
 };

--- a/ComposureWatch/src/Components/UI/Overview.jsx
+++ b/ComposureWatch/src/Components/UI/Overview.jsx
@@ -17,12 +17,14 @@ const Overview = () => {
         <Zcontentgrid>
           <Zheader header={header} />
           <Zcontent content={content} />
-          <button className="bg-orange-600 w-30 h-15 px-6 py-3 uppercase font-semibold rounded-sm opacity-80 hover:opacity-100">
-            Try now
-          </button>
-          <button className="bg-white text-black w-30 h-15 px-6 py-3 uppercase font-semibold rounded-sm opacity-80 hover:opacity-100">
-            Learn More
-          </button>
+          <div className="flex align-center justify-center gap-x-6 pt-8">
+            <button className="bg-orange-600 w-30 h-15 px-10 py-3 uppercase font-semibold rounded-sm opacity-80 hover:opacity-100">
+              Try now
+            </button>
+            <button className="bg-white text-black w-30 h-15 px-10 py-3 uppercase font-semibold rounded-sm opacity-80 hover:opacity-100">
+              Learn More
+            </button>
+          </div>
         </Zcontentgrid>
       </Zgridright>
     </div>

--- a/ComposureWatch/src/Components/UI/Overview.jsx
+++ b/ComposureWatch/src/Components/UI/Overview.jsx
@@ -17,11 +17,11 @@ const Overview = () => {
         <Zcontentgrid>
           <Zheader header={header} />
           <Zcontent content={content} />
-          <div className="flex align-center justify-center gap-x-6 pt-8">
-            <button className="bg-orange-600 w-30 h-15 px-10 py-3 uppercase font-semibold rounded-sm opacity-80 hover:opacity-100">
+          <div className="flex align-center justify-center md:gap-x-6 pt-8 flex-col md:flex-row gap-y-6">
+            <button className="bg-orange-600 w-30 h-15 px-10 py-3 uppercase font-semibold rounded-sm opacity-80 hover:opacity-100 whitespace-nowrap">
               Try now
             </button>
-            <button className="bg-white text-black w-30 h-15 px-10 py-3 uppercase font-semibold rounded-sm opacity-80 hover:opacity-100">
+            <button className="bg-white text-black w-30 h-15 px-10 py-3 uppercase font-semibold rounded-sm opacity-80 hover:opacity-100 whitespace-nowrap">
               Learn More
             </button>
           </div>

--- a/ComposureWatch/src/Components/UI/Overview.jsx
+++ b/ComposureWatch/src/Components/UI/Overview.jsx
@@ -1,31 +1,30 @@
 import doomfist from "../../images/UI/Doomfist.png";
+import Zcontentgrid from "./ZGridComponent/Zcontentgrid";
+import Zgrid from "./ZGridComponent/Zgrid";
+import Zheader from "./ZGridComponent/Zheader";
+import Zcontent from "./ZGridComponent/Zcontent";
+import Zimage from "./ZGridComponent/Zimage";
 
 const Overview = () => {
+  let header = "Card Overview";
+  let content =
+    "Experience the first major collaboration in Overwatch 2! Punch your way through new challenges to unlock free One-Punch Man themed rewards including a Legendary Mumen Rider- Soldier 76 skin, and collect the other themed skins like Saitama &#x2013; Doomfist, Genos &#x2013; Genji, and Terrible Tornado &#x2013; Kiriko.";
+  let alt = "Doomfist Image";
   return (
     <div className="bg-gradient-to-tr from-[#AE1518] via-[#8C1114] to-[#5B0B0E] flex justify-center">
-      <div className="flex flex-row justify-center items-start  text-white py-14 px-12 gap-x-12 max-w-7xl">
-        <div>
-          <img src={doomfist} alt="Doomfist" className="rounded" />
-        </div>
-        <div className="flex flex-col items-center">
-          <h2 className="text-6xl font-bold uppercase mb-6">Card Overview</h2>
-          <p className="mb-6">
-            Experience the first major collaboration in Overwatch 2! Punch your
-            way through new challenges to unlock free One-Punch Man themed
-            rewards including a Legendary Mumen Rider- Soldier 76 skin, and
-            collect the other themed skins like Saitama &#x2013; Doomfist, Genos
-            &#x2013; Genji, and Terrible Tornado &#x2013; Kiriko.
-          </p>
-          <div className="flex flex-row gap-x-4">
-            <button className="bg-orange-600 w-30 h-15 px-6 py-3 uppercase font-semibold rounded-sm opacity-80 hover:opacity-100">
-              Try now
-            </button>
-            <button className="bg-white text-black w-30 h-15 px-6 py-3 uppercase font-semibold rounded-sm opacity-80 hover:opacity-100">
-              Learn More
-            </button>
-          </div>
-        </div>
-      </div>
+      <Zgrid>
+        <Zimage img={doomfist} alt={alt} />
+        <Zcontentgrid>
+          <Zheader header={header} />
+          <Zcontent content={content} />
+          <button className="bg-orange-600 w-30 h-15 px-6 py-3 uppercase font-semibold rounded-sm opacity-80 hover:opacity-100">
+            Try now
+          </button>
+          <button className="bg-white text-black w-30 h-15 px-6 py-3 uppercase font-semibold rounded-sm opacity-80 hover:opacity-100">
+            Learn More
+          </button>
+        </Zcontentgrid>
+      </Zgrid>
     </div>
   );
 };

--- a/ComposureWatch/src/Components/UI/PurposeSection.jsx
+++ b/ComposureWatch/src/Components/UI/PurposeSection.jsx
@@ -1,6 +1,6 @@
 import kiriko from "../../images/UI/Kiriko.jpg";
 import Zcontentgrid from "./ZGridComponent/Zcontentgrid";
-import Zgrid from "./ZGridComponent/Zgrid";
+import Zgridleft from "./ZGridComponent/Zgridleft";
 import Zheader from "./ZGridComponent/Zheader";
 import Zcontent from "./ZGridComponent/Zcontent";
 import Zimage from "./ZGridComponent/Zimage";
@@ -13,13 +13,13 @@ const PurposeSection = () => {
 
   return (
     <div className="from-[#66c4ff] bg-gradient-to-tr via-[#33b1ff]to-[#009dff] flex items-center justify-center">
-      <Zgrid>
+      <Zgridleft>
         <Zcontentgrid>
           <Zheader header={header} />
           <Zcontent content={content} />
         </Zcontentgrid>
         <Zimage img={kiriko} alt={alt} />
-      </Zgrid>
+      </Zgridleft>
     </div>
   );
 };

--- a/ComposureWatch/src/Components/UI/ZGridComponent/Zgridleft.jsx
+++ b/ComposureWatch/src/Components/UI/ZGridComponent/Zgridleft.jsx
@@ -1,8 +1,8 @@
-const Zgrid = ({ children }) => {
+const Zgridleft = ({ children }) => {
   const classes =
     "grid grid-cols-1 md:grid-cols-[40fr,60fr] gap-x-20 max-[1200px]:gap-x-10 sm:gap-y-8 gap-y-6 px-4 py-10 sm:px-6 sm:py-16 md:px-10 md:py-20 justify-items-center items-center  font-[rgb(29, 37, 58)] max-w-[1600px] " +
     children.className;
 
   return <div className={classes}>{children}</div>;
 };
-export default Zgrid;
+export default Zgridleft;

--- a/ComposureWatch/src/Components/UI/ZGridComponent/Zgridright.jsx
+++ b/ComposureWatch/src/Components/UI/ZGridComponent/Zgridright.jsx
@@ -1,0 +1,8 @@
+const Zgridright = ({ children }) => {
+  const classes =
+    "grid grid-cols-1 md:grid-cols-[60fr,40fr] gap-x-20 max-[1200px]:gap-x-10 sm:gap-y-8 gap-y-6 px-4 py-10 sm:px-6 sm:py-16 md:px-10 md:py-20 justify-items-center items-center text-white max-w-[1600px] " +
+    children.className;
+
+  return <div className={classes}>{children}</div>;
+};
+export default Zgridright;


### PR DESCRIPTION
**What did you do?**

- Applied Zgrid components to overview section.  
- Split Zgrid into Zgridleft and Zgridright for future component possibilities.
- Modified buttons in Overview section for responsive design.


**Why did you do it?**

- The Overview section component was not responsive for smaller screens. 
- To expand upon a set of Zgrid tools that can be applied to future cards in the Z-grid layout.
- Improve the overall aesthetic quality of ComposureWatch.

**Screenshot before:**
![image](https://user-images.githubusercontent.com/6788405/231907510-27f7624a-d051-40b5-8c3d-7d76f04d89b8.png)

**Screenshot after:**
![image](https://user-images.githubusercontent.com/6788405/231907401-64dced97-ddb8-4b20-b030-d4034fd632db.png)
