### PR TITLE
Player Cards Saved to Local Storage 

### DIFF
--- a/ComposureWatch/src/Components/Card/CreateCard.jsx
+++ b/ComposureWatch/src/Components/Card/CreateCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import CardForm from "./CardForm";
 import CardList from "./CardList";
 import SortingLogic from "../Sorting/SortingLogic";
@@ -14,7 +14,18 @@ const DUMMY_CARDS = [
 ];
 
 const CreateCard = () => {
-  const [cards, setCards] = useState(DUMMY_CARDS);
+  const [cards, setCards] = usePersistState([], "cards");
+
+  function usePersistState(defaultValue, key) {
+    const [value, setValue] = React.useState(() => {
+      const persistValue = window.localStorage.getItem(key);
+      return persistValue !== null ? JSON.parse(persistValue) : defaultValue;
+    });
+    React.useEffect(() => {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    }, [key, value]);
+    return [value, setValue];
+  }
 
   const [kumite, setKumite] = useState(false);
 

--- a/ComposureWatch/src/Components/Card/CreateCard.jsx
+++ b/ComposureWatch/src/Components/Card/CreateCard.jsx
@@ -3,16 +3,6 @@ import CardForm from "./CardForm";
 import CardList from "./CardList";
 import SortingLogic from "../Sorting/SortingLogic";
 
-const DUMMY_CARDS = [
-  {
-    id: 1337,
-    name: "Zen",
-    character: "ana",
-    rank: "platinum3",
-    rating: 1.35,
-  },
-];
-
 const CreateCard = () => {
   const [cards, setCards] = usePersistState([], "cards");
 


### PR DESCRIPTION
**What did you do?**
Added a custom hook that will save "cards" state to local browser storage.
Removed default "Dummy_Cards" list that produced "Zen" Card.

**Why did you do it?**
This feature allows player cards to be saved locally.  This means if a user plays with the same group of people consistently, their cards will be saved for them.

**Screenshots:**
**Before:**
![LocalStorage-before](https://github.com/cityscapedview/ComposureWatch/assets/6788405/0b254872-803f-496d-bca0-68766f1b672f)


**After:**
![LocalStorage-after](https://github.com/cityscapedview/ComposureWatch/assets/6788405/60d8f2b4-87d4-454c-821a-bbeb858feaa6)
